### PR TITLE
Add True/False question kind to Admin Exam Builder and change exam listing sort order

### DIFF
--- a/backend/src/controllers/examController.js
+++ b/backend/src/controllers/examController.js
@@ -79,7 +79,7 @@ export const getExams = async (req, res) => {
     }
 
     const persistedExams = await Exam.find(query)
-      .sort({ examId: 1 })
+      .sort({ createdAt: -1, updatedAt: -1, examId: 1 })
       .select("-questions -essayContent")
       .lean();
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ import AdminDashboardPage from "./pages/AdminDashboardPage";
 import AdminNotificationsPage from "./pages/AdminNotificationsPage";
 import AdminAnalyticsPage from "./pages/AdminAnalyticsPage";
 import AdminExamBuilderPage from "./pages/AdminExamBuilderPage";
+import AdminMockExamInformaticsPage from "./pages/AdminMockExamInformaticsPage";
 
 function App() {
   const { isDark, setTheme } = useThemeStore();
@@ -90,6 +91,7 @@ function App() {
             />
             <Route path="/admin/analytics" element={<AdminAnalyticsPage />} />
             <Route path="/admin/exams/new" element={<AdminExamBuilderPage />} />
+            <Route path="/admin/exams/informatics-mock" element={<AdminMockExamInformaticsPage />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/frontend/src/components/admin/AdminShell.tsx
+++ b/frontend/src/components/admin/AdminShell.tsx
@@ -52,6 +52,13 @@ const adminMenuItems: AdminMenuItem[] = [
     path: "/admin/exams/new",
   },
   {
+    key: "mock-informatics",
+    label: "Thi thử Tin học",
+    description: "Tạo đề 24 + 4 Đ/S",
+    icon: FilePlus2,
+    path: "/admin/exams/informatics-mock",
+  },
+  {
     key: "notifications",
     label: "Thông báo",
     description: "Gửi nhắc nhở và bài mới",

--- a/frontend/src/pages/AdminExamBuilderPage.tsx
+++ b/frontend/src/pages/AdminExamBuilderPage.tsx
@@ -25,9 +25,12 @@ import { toast } from "sonner";
 type ExamCategory = "illustration" | "specialized" | "self-study";
 type ExamType = "multiple_choice" | "essay";
 
+type QuestionKind = "multiple_choice" | "true_false";
+
 type QuestionForm = {
   topicLabel: string;
   prompt: string;
+  kind: QuestionKind;
   options: string[];
   correctIndex: number;
   hint: string;
@@ -65,10 +68,11 @@ const categoryOptions: Array<{ value: ExamCategory; label: string; description: 
   },
 ];
 
-const createEmptyQuestion = (): QuestionForm => ({
+const createEmptyQuestion = (kind: QuestionKind = "multiple_choice"): QuestionForm => ({
   topicLabel: "",
   prompt: "",
-  options: ["", "", "", ""],
+  kind,
+  options: kind === "true_false" ? ["Đúng", "Sai"] : ["", "", "", ""],
   correctIndex: 0,
   hint: "",
   formula: "",
@@ -171,6 +175,35 @@ export default function AdminExamBuilderPage() {
     setQuestions((current) => [...current, createEmptyQuestion()]);
   };
 
+  const handleChangeQuestionKind = (index: number, kind: QuestionKind) => {
+    setQuestions((current) =>
+      current.map((question, questionIndex) => {
+        if (questionIndex !== index) {
+          return question;
+        }
+
+        if (kind === "true_false") {
+          return {
+            ...question,
+            kind,
+            options: ["Đúng", "Sai"],
+            correctIndex: question.correctIndex > 1 ? 0 : question.correctIndex,
+          };
+        }
+
+        return {
+          ...question,
+          kind,
+          options:
+            question.options.length >= 4
+              ? question.options.slice(0, 4)
+              : [...question.options, ...Array.from({ length: 4 - question.options.length }, () => "")],
+          correctIndex: Math.min(question.correctIndex, 3),
+        };
+      })
+    );
+  };
+
   const handleRemoveQuestion = (index: number) => {
     setQuestions((current) => {
       if (current.length === 1) {
@@ -225,7 +258,9 @@ export default function AdminExamBuilderPage() {
       payload.questions = questions.map((question) => ({
         topicLabel: normalizeText(question.topicLabel),
         prompt: question.prompt.trim(),
-        options: question.options.map((option) => option.trim()).filter(Boolean),
+        options: (question.kind === "true_false" ? ["Đúng", "Sai"] : question.options)
+          .map((option) => option.trim())
+          .filter(Boolean),
         correctIndex: question.correctIndex,
         hint: question.hint.trim(),
         formula: question.formula.trim(),
@@ -518,6 +553,31 @@ export default function AdminExamBuilderPage() {
                         className="min-h-24 rounded-[1rem] border-border/75 bg-card px-3 py-2.5 text-[13px]"
                       />
 
+                      <div className="space-y-1.5">
+                        <p className="text-[11px] font-bold uppercase tracking-[0.16em] text-muted-foreground">
+                          Dạng câu hỏi
+                        </p>
+                        <div className="flex gap-2">
+                          {[
+                            { value: "multiple_choice", label: "Trắc nghiệm" },
+                            { value: "true_false", label: "Đúng / Sai" },
+                          ].map((item) => (
+                            <button
+                              key={`kind-${index}-${item.value}`}
+                              type="button"
+                              className={`rounded-[0.9rem] border px-3 py-2 text-[12px] font-bold transition ${
+                                question.kind === item.value
+                                  ? "border-primary bg-primary/10 text-primary"
+                                  : "border-border bg-card text-muted-foreground hover:border-primary/16 hover:text-primary"
+                              }`}
+                              onClick={() => handleChangeQuestionKind(index, item.value as QuestionKind)}
+                            >
+                              {item.label}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+
                       <div className="grid gap-2 md:grid-cols-2">
                         {question.options.map((option, optionIndex) => (
                           <div key={`question-${index}-option-${optionIndex}`} className="space-y-1.5">
@@ -531,6 +591,7 @@ export default function AdminExamBuilderPage() {
                               }
                               placeholder={`Nhập đáp án ${String.fromCharCode(65 + optionIndex)}`}
                               className="h-10 rounded-[0.95rem] border-border/75 bg-card text-[13px]"
+                              disabled={question.kind === "true_false"}
                             />
                           </div>
                         ))}

--- a/frontend/src/pages/AdminMockExamInformaticsPage.tsx
+++ b/frontend/src/pages/AdminMockExamInformaticsPage.tsx
@@ -1,0 +1,135 @@
+import AdminShell from "@/components/admin/AdminShell";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { adminService, type AdminCreateExamPayload } from "@/services/adminService";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+
+type McqQuestion = { prompt: string; options: string[]; correctIndex: number };
+type TfGroup = { prompt: string; statements: Array<{ text: string; isTrue: boolean }> };
+
+const createMcq = (): McqQuestion => ({ prompt: "", options: ["", "", "", ""], correctIndex: 0 });
+const createTfGroup = (): TfGroup => ({
+  prompt: "",
+  statements: Array.from({ length: 4 }, () => ({ text: "", isTrue: true })),
+});
+
+export default function AdminMockExamInformaticsPage() {
+  const [title, setTitle] = useState("");
+  const [duration, setDuration] = useState("50");
+  const [mcq, setMcq] = useState<McqQuestion[]>(Array.from({ length: 24 }, createMcq));
+  const [tfGroups, setTfGroups] = useState<TfGroup[]>(Array.from({ length: 4 }, createTfGroup));
+  const [submitting, setSubmitting] = useState(false);
+
+  const totalFilled = useMemo(() => {
+    const mcqFilled = mcq.filter((q) => q.prompt.trim()).length;
+    const tfFilled = tfGroups.filter((g) => g.prompt.trim()).length;
+    return mcqFilled + tfFilled;
+  }, [mcq, tfGroups]);
+
+  const handleSubmit = async () => {
+    const examTitle = title.trim();
+    const durationMinutes = Number(duration);
+
+    if (!examTitle) return toast.error("Nhập tiêu đề đề thi.");
+    if (!Number.isFinite(durationMinutes) || durationMinutes < 1) return toast.error("Thời lượng không hợp lệ.");
+
+    const flattenedTrueFalse = tfGroups.flatMap((group, groupIndex) =>
+      group.statements.map((item, statementIndex) => ({
+        topicLabel: "Đúng/Sai",
+        prompt: `${group.prompt.trim()}\nÝ ${String.fromCharCode(97 + statementIndex)}: ${item.text.trim()}`,
+        options: ["Đúng", "Sai"],
+        correctIndex: item.isTrue ? 0 : 1,
+        hint: "",
+        formula: "",
+        explanationTitle: `Câu Đ/S ${groupIndex + 1}${String.fromCharCode(97 + statementIndex)}`,
+        explanationSteps: [],
+        explanationConclusion: "",
+      }))
+    );
+
+    const payload: AdminCreateExamPayload = {
+      subject: "Tin học",
+      examType: "multiple_choice",
+      title: examTitle,
+      durationMinutes,
+      difficulty: "Khó",
+      category: "specialized",
+      badge: "Thi thử mới",
+      imageUrl: "",
+      questions: [
+        ...mcq.map((question, index) => ({
+          topicLabel: "Trắc nghiệm 4 lựa chọn",
+          prompt: question.prompt.trim() || `Câu ${index + 1}`,
+          options: question.options.map((o) => o.trim()).filter(Boolean),
+          correctIndex: question.correctIndex,
+          hint: "",
+          formula: "",
+          explanationTitle: "",
+          explanationSteps: [],
+          explanationConclusion: "",
+        })),
+        ...flattenedTrueFalse,
+      ],
+    };
+
+    try {
+      setSubmitting(true);
+      await adminService.createExam(payload);
+      toast.success("Đã đẩy đề lên Thi thử môn Tin học.");
+    } catch (error) {
+      console.error(error);
+      toast.error("Tạo đề thất bại.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <AdminShell title="Tạo đề Thi thử Tin học" description="Mặc định 24 câu trắc nghiệm 4 lựa chọn + 4 câu Đúng/Sai (mỗi câu 4 ý). Khi lưu sẽ tự hiển thị cho user trong môn Tin học.">
+      <section className="space-y-4 rounded-2xl border bg-card p-4">
+        <div className="grid gap-3 md:grid-cols-2">
+          <Input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Tiêu đề đề thi thử" />
+          <Input value={duration} onChange={(e) => setDuration(e.target.value)} inputMode="numeric" placeholder="Thời gian (phút)" />
+        </div>
+        <p className="text-xs text-muted-foreground">Đã điền: {totalFilled}/28 cụm câu.</p>
+
+        <h3 className="font-bold">Phần I - 24 câu trắc nghiệm</h3>
+        <div className="space-y-3">
+          {mcq.map((q, i) => (
+            <div key={i} className="rounded-xl border p-3 space-y-2">
+              <Textarea value={q.prompt} onChange={(e) => setMcq((cur) => cur.map((x, idx) => idx === i ? { ...x, prompt: e.target.value } : x))} placeholder={`Câu ${i + 1}`} />
+              <div className="grid grid-cols-2 gap-2">
+                {q.options.map((op, oi) => (
+                  <Input key={oi} value={op} onChange={(e) => setMcq((cur) => cur.map((x, idx) => idx === i ? { ...x, options: x.options.map((v, vi) => vi === oi ? e.target.value : v) } : x))} placeholder={`Đáp án ${String.fromCharCode(65 + oi)}`} />
+                ))}
+              </div>
+              <div className="flex gap-2">{[0,1,2,3].map((n) => <Button key={n} type="button" variant={q.correctIndex===n?"default":"outline"} onClick={() => setMcq((cur)=>cur.map((x,idx)=>idx===i?{...x,correctIndex:n}:x))}>{String.fromCharCode(65+n)}</Button>)}</div>
+            </div>
+          ))}
+        </div>
+
+        <h3 className="font-bold">Phần II - 4 câu Đúng/Sai (mỗi câu 4 ý)</h3>
+        <div className="space-y-3">
+          {tfGroups.map((g, gi) => (
+            <div key={gi} className="rounded-xl border p-3 space-y-2">
+              <Textarea value={g.prompt} onChange={(e)=>setTfGroups((cur)=>cur.map((x,idx)=>idx===gi?{...x,prompt:e.target.value}:x))} placeholder={`Câu Đ/S ${gi+1} - đoạn dẫn`} />
+              {g.statements.map((s, si) => (
+                <div key={si} className="grid grid-cols-[1fr_auto] gap-2 items-center">
+                  <Input value={s.text} onChange={(e)=>setTfGroups((cur)=>cur.map((x,idx)=>idx===gi?{...x,statements:x.statements.map((st,sti)=>sti===si?{...st,text:e.target.value}:st)}:x))} placeholder={`Ý ${String.fromCharCode(97+si)}`} />
+                  <div className="flex gap-1">
+                    <Button type="button" size="sm" variant={s.isTrue?"default":"outline"} onClick={()=>setTfGroups((cur)=>cur.map((x,idx)=>idx===gi?{...x,statements:x.statements.map((st,sti)=>sti===si?{...st,isTrue:true}:st)}:x))}>Đúng</Button>
+                    <Button type="button" size="sm" variant={!s.isTrue?"default":"outline"} onClick={()=>setTfGroups((cur)=>cur.map((x,idx)=>idx===gi?{...x,statements:x.statements.map((st,sti)=>sti===si?{...st,isTrue:false}:st)}:x))}>Sai</Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+
+        <div className="flex justify-end"><Button type="button" onClick={() => void handleSubmit()} disabled={submitting}>{submitting ? "Đang lưu..." : "Đăng đề Thi thử Tin học"}</Button></div>
+      </section>
+    </AdminShell>
+  );
+}


### PR DESCRIPTION
### Motivation

- Allow authors to create `true_false` (Đúng / Sai) questions in the admin exam builder to support simpler binary questions.
- Ensure exam listing returns more recent exams first by preferring `createdAt`/`updatedAt` while still using `examId` as a tiebreaker.

### Description

- Backend: changed the exam query sort to `sort({ createdAt: -1, updatedAt: -1, examId: 1 })` so newer exams are listed first.
- Frontend: introduced a `QuestionKind` type and added a `kind` field to `QuestionForm` to represent `multiple_choice` or `true_false` questions.
- Frontend: updated `createEmptyQuestion` to accept a `kind` and initialize `options` to `[

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e0f8bff08322a52253eee07ef292)