### PR TITLE
Add questionCode field, True/False support and Informatics mock exam with custom scoring

### DIFF
--- a/backend/src/controllers/examController.js
+++ b/backend/src/controllers/examController.js
@@ -51,6 +51,12 @@ const toSlugFragment = (value = "") =>
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
 
+const sanitizeQuestionCode = (value = "") =>
+  normalizeText(value)
+    .toUpperCase()
+    .replace(/\s+/g, "")
+    .replace(/[^A-Z0-9._-]/g, "");
+
 export const getExams = async (req, res) => {
   try {
     try {
@@ -79,7 +85,7 @@ export const getExams = async (req, res) => {
     }
 
     const persistedExams = await Exam.find(query)
-      .sort({ examId: 1 })
+      .sort({ createdAt: -1, updatedAt: -1, examId: 1 })
       .select("-questions -essayContent")
       .lean();
 
@@ -239,6 +245,7 @@ export const createAdminExam = async (req, res) => {
         return {
           id: index + 1,
           topicLabel: normalizeText(question?.topicLabel),
+          questionCode: sanitizeQuestionCode(question?.questionCode),
           prompt,
           imageUrl: normalizeText(question?.imageUrl),
           hint: normalizeText(question?.hint),

--- a/backend/src/models/Exam.js
+++ b/backend/src/models/Exam.js
@@ -12,6 +12,12 @@ const examQuestionSchema = new mongoose.Schema(
       trim: true,
       default: "",
     },
+    questionCode: {
+      type: String,
+      trim: true,
+      default: "",
+      index: true,
+    },
     prompt: {
       type: String,
       required: true,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ import AdminDashboardPage from "./pages/AdminDashboardPage";
 import AdminNotificationsPage from "./pages/AdminNotificationsPage";
 import AdminAnalyticsPage from "./pages/AdminAnalyticsPage";
 import AdminExamBuilderPage from "./pages/AdminExamBuilderPage";
+import AdminMockExamInformaticsPage from "./pages/AdminMockExamInformaticsPage";
 
 function App() {
   const { isDark, setTheme } = useThemeStore();
@@ -90,6 +91,7 @@ function App() {
             />
             <Route path="/admin/analytics" element={<AdminAnalyticsPage />} />
             <Route path="/admin/exams/new" element={<AdminExamBuilderPage />} />
+            <Route path="/admin/exams/informatics-mock" element={<AdminMockExamInformaticsPage />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,7 +31,7 @@ function App() {
 
   useEffect(() => {
     setTheme(isDark);
-  }, [isDark]);
+  }, [isDark, setTheme]);
 
   useEffect(() => {
     if (accessToken) {
@@ -39,7 +39,7 @@ function App() {
     }
 
     return () => disconnectSocket();
-  }, [accessToken]);
+  }, [accessToken, connectSocket, disconnectSocket]);
 
   return (
     <>

--- a/frontend/src/components/admin/AdminShell.tsx
+++ b/frontend/src/components/admin/AdminShell.tsx
@@ -52,6 +52,13 @@ const adminMenuItems: AdminMenuItem[] = [
     path: "/admin/exams/new",
   },
   {
+    key: "mock-informatics",
+    label: "Thi thử Tin học",
+    description: "Tạo đề 24 + 4 Đ/S",
+    icon: FilePlus2,
+    path: "/admin/exams/informatics-mock",
+  },
+  {
     key: "notifications",
     label: "Thông báo",
     description: "Gửi nhắc nhở và bài mới",

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -1,7 +1,7 @@
 import type { UserRole } from "@/types/user";
 import { AppLoadingScreen } from "@/components/auth/AppLoadingScreen";
 import { useAuthStore } from "@/stores/useAuthStore";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Navigate, Outlet } from "react-router";
 
 type ProtectedRouteProps = {
@@ -14,7 +14,7 @@ const ProtectedRoute = ({ allowedRoles }: ProtectedRouteProps) => {
   const { accessToken, loading, refresh, fetchMe } = useAuthStore();
   const [starting, setStarting] = useState(true);
 
-  const init = async () => {
+  const init = useCallback(async () => {
     try {
       const authState = useAuthStore.getState();
 
@@ -30,11 +30,11 @@ const ProtectedRoute = ({ allowedRoles }: ProtectedRouteProps) => {
     } finally {
       setStarting(false);
     }
-  };
+  }, [fetchMe, refresh]);
 
   useEffect(() => {
     init();
-  }, []);
+  }, [init]);
 
   if (starting || loading) {
     return <AppLoadingScreen message="Đang tải trang..." />;

--- a/frontend/src/components/auth/signin-form.tsx
+++ b/frontend/src/components/auth/signin-form.tsx
@@ -89,7 +89,18 @@ export function SigninForm() {
     script.defer = true;
 
     script.onload = () => {
-      const google = (window as any).google;
+      const google = (window as Window & { google?: { accounts?: { id?: {
+        initialize: (config: {
+          client_id: string;
+          callback: (response: { credential?: string }) => void;
+          ux_mode: "popup";
+          auto_select: boolean;
+        }) => void;
+        renderButton: (
+          el: HTMLElement,
+          options: { type: string; theme: string; size: string; width: string; text: string }
+        ) => void;
+      } } } }).google;
 
       if (!google?.accounts?.id) {
         return;
@@ -140,7 +151,7 @@ export function SigninForm() {
     try {
       const PasswordCredentialCtor = (
         window as Window & {
-          PasswordCredential?: new (form: HTMLFormElement) => any;
+          PasswordCredential?: new (form: HTMLFormElement) => Credential;
         }
       ).PasswordCredential;
 

--- a/frontend/src/components/chat/EmojiPicker.tsx
+++ b/frontend/src/components/chat/EmojiPicker.tsx
@@ -26,7 +26,9 @@ const EmojiPicker = ({ onChange, triggerClassName }: EmojiPickerProps) => {
         <Picker
           theme={isDark ? "dark" : "light"}
           data={data}
-          onEmojiSelect={(emoji: any) => onChange(emoji.native)}
+          onEmojiSelect={(emoji: unknown) =>
+            onChange((emoji as { native?: string }).native ?? "")
+          }
           emojiSize={24}
         />
       </PopoverContent>

--- a/frontend/src/components/chat/MessageInput.tsx
+++ b/frontend/src/components/chat/MessageInput.tsx
@@ -34,8 +34,6 @@ const MessageInput = ({ selectedConvo }: { selectedConvo: Conversation }) => {
   const [durationMinutesInput, setDurationMinutesInput] = useState("50");
   const inputRef = useRef<HTMLInputElement>(null);
 
-  if (!user) return;
-
   const topicOptions = useMemo(() => {
     if (!informaticsTemplate) {
       return [];
@@ -117,6 +115,7 @@ const MessageInput = ({ selectedConvo }: { selectedConvo: Conversation }) => {
   }, [createExamOpen, informaticsTemplate, selectedConvo.type]);
 
   const sendMessage = async () => {
+    if (!user) return;
     if (!value.trim()) return;
     const currValue = value;
     setValue("");

--- a/frontend/src/components/chat/SchoolScheduleSetupDialog.tsx
+++ b/frontend/src/components/chat/SchoolScheduleSetupDialog.tsx
@@ -175,6 +175,7 @@ export default function SchoolScheduleSetupDialog({
     setNewSubjectName("");
     setError("");
     setIsSaving(false);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, open]);
 
   useEffect(() => {

--- a/frontend/src/components/exam/RichQuestionContent.tsx
+++ b/frontend/src/components/exam/RichQuestionContent.tsx
@@ -15,10 +15,7 @@ export const decodeHtmlEntities = (value: string) =>
 
 const renderTextWithBreaks = (text: string, keyPrefix: string) => {
   const normalized = decodeHtmlEntities(text).replace(/<br\s*\/?>/gi, "\n");
-  const lines = normalized
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean);
+  const lines = normalized.split("\n");
 
   if (lines.length === 0) {
     return null;
@@ -26,16 +23,23 @@ const renderTextWithBreaks = (text: string, keyPrefix: string) => {
 
   return (
     <div className="space-y-2">
-      {lines.map((line, index) => (
-        <p key={`${keyPrefix}-${index}`}>{line}</p>
-      ))}
+      {lines.map((line, index) =>
+        line.trim().length > 0 ? (
+          <p key={`${keyPrefix}-${index}`} className="whitespace-pre-wrap break-words">
+            {line}
+          </p>
+        ) : (
+          <div key={`${keyPrefix}-${index}`} className="h-2" />
+        )
+      )}
     </div>
   );
 };
 
 const RichQuestionContent = ({ content, className }: RichQuestionContentProps) => {
   const blocks: Array<{ type: "text" | "code"; value: string }> = [];
-  const codeBlockRegex = /<pre>\s*<code>([\s\S]*?)<\/code>\s*<\/pre>/gi;
+  const codeBlockRegex =
+    /<pre>\s*<code>([\s\S]*?)<\/code>\s*<\/pre>|```(?:[a-zA-Z0-9_+-]+)?\n([\s\S]*?)```/gi;
 
   let lastIndex = 0;
   let match: RegExpExecArray | null = null;
@@ -46,7 +50,7 @@ const RichQuestionContent = ({ content, className }: RichQuestionContentProps) =
       blocks.push({ type: "text", value: before });
     }
 
-    blocks.push({ type: "code", value: match[1] });
+    blocks.push({ type: "code", value: match[1] || match[2] || "" });
     lastIndex = match.index + match[0].length;
   }
 

--- a/frontend/src/components/exam/RichQuestionContent.tsx
+++ b/frontend/src/components/exam/RichQuestionContent.tsx
@@ -5,7 +5,7 @@ type RichQuestionContentProps = {
   className?: string;
 };
 
-export const decodeHtmlEntities = (value: string) =>
+const decodeHtmlEntities = (value: string) =>
   value
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")

--- a/frontend/src/components/friendRequest/FriendRequestDialog.tsx
+++ b/frontend/src/components/friendRequest/FriendRequestDialog.tsx
@@ -29,7 +29,7 @@ const FriendRequestDialog = ({ open, setOpen }: FriendRequestDialogProps) => {
     };
 
     loadRequest();
-  }, []);
+  }, [getAllFriendRequests]);
 
   return (
     <Dialog

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -43,4 +43,5 @@ function Badge({
   )
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export { Badge, badgeVariants }

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -61,4 +61,5 @@ function Button({
   );
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export { Button, buttonVariants };

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";

--- a/frontend/src/pages/AdminExamBuilderPage.tsx
+++ b/frontend/src/pages/AdminExamBuilderPage.tsx
@@ -25,9 +25,13 @@ import { toast } from "sonner";
 type ExamCategory = "illustration" | "specialized" | "self-study";
 type ExamType = "multiple_choice" | "essay";
 
+type QuestionKind = "multiple_choice" | "true_false";
+
 type QuestionForm = {
   topicLabel: string;
+  questionCode: string;
   prompt: string;
+  kind: QuestionKind;
   options: string[];
   correctIndex: number;
   hint: string;
@@ -65,10 +69,12 @@ const categoryOptions: Array<{ value: ExamCategory; label: string; description: 
   },
 ];
 
-const createEmptyQuestion = (): QuestionForm => ({
+const createEmptyQuestion = (kind: QuestionKind = "multiple_choice"): QuestionForm => ({
   topicLabel: "",
+  questionCode: "",
   prompt: "",
-  options: ["", "", "", ""],
+  kind,
+  options: kind === "true_false" ? ["Đúng", "Sai"] : ["", "", "", ""],
   correctIndex: 0,
   hint: "",
   formula: "",
@@ -171,6 +177,35 @@ export default function AdminExamBuilderPage() {
     setQuestions((current) => [...current, createEmptyQuestion()]);
   };
 
+  const handleChangeQuestionKind = (index: number, kind: QuestionKind) => {
+    setQuestions((current) =>
+      current.map((question, questionIndex) => {
+        if (questionIndex !== index) {
+          return question;
+        }
+
+        if (kind === "true_false") {
+          return {
+            ...question,
+            kind,
+            options: ["Đúng", "Sai"],
+            correctIndex: question.correctIndex > 1 ? 0 : question.correctIndex,
+          };
+        }
+
+        return {
+          ...question,
+          kind,
+          options:
+            question.options.length >= 4
+              ? question.options.slice(0, 4)
+              : [...question.options, ...Array.from({ length: 4 - question.options.length }, () => "")],
+          correctIndex: Math.min(question.correctIndex, 3),
+        };
+      })
+    );
+  };
+
   const handleRemoveQuestion = (index: number) => {
     setQuestions((current) => {
       if (current.length === 1) {
@@ -224,8 +259,11 @@ export default function AdminExamBuilderPage() {
     if (examType === "multiple_choice") {
       payload.questions = questions.map((question) => ({
         topicLabel: normalizeText(question.topicLabel),
+        questionCode: normalizeText(question.questionCode).toUpperCase().replace(/\s+/g, ""),
         prompt: question.prompt.trim(),
-        options: question.options.map((option) => option.trim()).filter(Boolean),
+        options: (question.kind === "true_false" ? ["Đúng", "Sai"] : question.options)
+          .map((option) => option.trim())
+          .filter(Boolean),
         correctIndex: question.correctIndex,
         hint: question.hint.trim(),
         formula: question.formula.trim(),
@@ -509,6 +547,13 @@ export default function AdminExamBuilderPage() {
                         placeholder="Chủ đề, ví dụ: Hàm số, OOP, Sóng cơ..."
                         className="h-10 rounded-[0.95rem] border-border/75 bg-card text-[13px]"
                       />
+                      <Input
+                        value={question.questionCode}
+                        onChange={(event) => updateQuestion(index, { questionCode: event.target.value })}
+                        placeholder={question.kind === "true_false" ? "Mã gợi ý: TH-DS-01A" : "Mã gợi ý: TH-MC-001"}
+                        className="h-10 rounded-[0.95rem] border-border/75 bg-card text-[13px]"
+                      />
+                      <p className="text-[11px] text-muted-foreground">Gợi ý mã: Trắc nghiệm dùng TH-MC-001, TH-MC-002... | Đúng/Sai dùng TH-DS-01A, TH-DS-01B...</p>
                       <Textarea
                         value={question.prompt}
                         onChange={(event) =>
@@ -517,6 +562,31 @@ export default function AdminExamBuilderPage() {
                         placeholder="Nội dung câu hỏi"
                         className="min-h-24 rounded-[1rem] border-border/75 bg-card px-3 py-2.5 text-[13px]"
                       />
+
+                      <div className="space-y-1.5">
+                        <p className="text-[11px] font-bold uppercase tracking-[0.16em] text-muted-foreground">
+                          Dạng câu hỏi
+                        </p>
+                        <div className="flex gap-2">
+                          {[
+                            { value: "multiple_choice", label: "Trắc nghiệm" },
+                            { value: "true_false", label: "Đúng / Sai" },
+                          ].map((item) => (
+                            <button
+                              key={`kind-${index}-${item.value}`}
+                              type="button"
+                              className={`rounded-[0.9rem] border px-3 py-2 text-[12px] font-bold transition ${
+                                question.kind === item.value
+                                  ? "border-primary bg-primary/10 text-primary"
+                                  : "border-border bg-card text-muted-foreground hover:border-primary/16 hover:text-primary"
+                              }`}
+                              onClick={() => handleChangeQuestionKind(index, item.value as QuestionKind)}
+                            >
+                              {item.label}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
 
                       <div className="grid gap-2 md:grid-cols-2">
                         {question.options.map((option, optionIndex) => (
@@ -531,6 +601,7 @@ export default function AdminExamBuilderPage() {
                               }
                               placeholder={`Nhập đáp án ${String.fromCharCode(65 + optionIndex)}`}
                               className="h-10 rounded-[0.95rem] border-border/75 bg-card text-[13px]"
+                              disabled={question.kind === "true_false"}
                             />
                           </div>
                         ))}

--- a/frontend/src/pages/AdminMockExamInformaticsPage.tsx
+++ b/frontend/src/pages/AdminMockExamInformaticsPage.tsx
@@ -2,14 +2,41 @@ import AdminShell from "@/components/admin/AdminShell";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { adminService, type AdminCreateExamPayload } from "@/services/adminService";
+import {
+  adminService,
+  type AdminCreateExamPayload,
+} from "@/services/adminService";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 
-type McqQuestion = { questionCode: string; prompt: string; options: string[]; correctIndex: number };
-type TfGroup = { prompt: string; statements: Array<{ code: string; text: string; isTrue: boolean }> };
+type McqQuestion = {
+  questionCode: string;
+  prompt: string;
+  options: string[];
+  correctIndex: number;
+};
 
-const createMcq = (): McqQuestion => ({ questionCode: "", prompt: "", options: ["", "", "", ""], correctIndex: 0 });
+type TfStatement = {
+  code: string;
+  text: string;
+  isTrue: boolean;
+};
+
+type TfGroup = {
+  prompt: string;
+  statements: TfStatement[];
+};
+
+const sanitizeCode = (value: string) =>
+  value.trim().toUpperCase().replace(/\s+/g, "").replace(/[^A-Z0-9._-]/g, "");
+
+const createMcq = (): McqQuestion => ({
+  questionCode: "",
+  prompt: "",
+  options: ["", "", "", ""],
+  correctIndex: 0,
+});
+
 const createTfGroup = (): TfGroup => ({
   prompt: "",
   statements: Array.from({ length: 4 }, () => ({ code: "", text: "", isTrue: true })),
@@ -33,13 +60,19 @@ export default function AdminMockExamInformaticsPage() {
     const durationMinutes = Number(duration);
 
     if (!examTitle) return toast.error("Nhập tiêu đề đề thi.");
-    if (!Number.isFinite(durationMinutes) || durationMinutes < 1) return toast.error("Thời lượng không hợp lệ.");
+    if (!Number.isFinite(durationMinutes) || durationMinutes < 1) {
+      return toast.error("Thời lượng không hợp lệ.");
+    }
 
     const flattenedTrueFalse = tfGroups.flatMap((group, groupIndex) =>
       group.statements.map((item, statementIndex) => ({
         topicLabel: "Đúng/Sai",
-        questionCode: (item.code || `TH-DS-${groupIndex + 1}${String.fromCharCode(65 + statementIndex)}`).trim().toUpperCase().replace(/\s+/g, ""),
-        prompt: `${group.prompt.trim()}\nÝ ${String.fromCharCode(97 + statementIndex)}: ${item.text.trim()}`,
+        questionCode:
+          sanitizeCode(item.code) ||
+          `TH-DS-${groupIndex + 1}${String.fromCharCode(65 + statementIndex)}`,
+        prompt: `${group.prompt.trim()}\nÝ ${String.fromCharCode(97 + statementIndex)}: ${
+          item.text
+        }`,
         options: ["Đúng", "Sai"],
         correctIndex: item.isTrue ? 0 : 1,
         hint: "",
@@ -47,7 +80,7 @@ export default function AdminMockExamInformaticsPage() {
         explanationTitle: `Câu Đ/S ${groupIndex + 1}${String.fromCharCode(97 + statementIndex)}`,
         explanationSteps: [],
         explanationConclusion: "",
-      }))
+      })),
     );
 
     const payload: AdminCreateExamPayload = {
@@ -62,7 +95,9 @@ export default function AdminMockExamInformaticsPage() {
       questions: [
         ...mcq.map((question, index) => ({
           topicLabel: "Trắc nghiệm 4 lựa chọn",
-          questionCode: (question.questionCode || `TH-MC-${String(index + 1).padStart(3, "0")}`).trim().toUpperCase().replace(/\s+/g, ""),
+          questionCode:
+            sanitizeCode(question.questionCode) ||
+            `TH-MC-${String(index + 1).padStart(3, "0")}`,
           prompt: question.prompt.trim() || `Câu ${index + 1}`,
           options: question.options.map((o) => o.trim()).filter(Boolean),
           correctIndex: question.correctIndex,
@@ -89,26 +124,85 @@ export default function AdminMockExamInformaticsPage() {
   };
 
   return (
-    <AdminShell title="Tạo đề Thi thử Tin học" description="Mặc định 24 câu trắc nghiệm 4 lựa chọn + 4 câu Đúng/Sai (mỗi câu 4 ý). Khi lưu sẽ tự hiển thị cho user trong môn Tin học.">
+    <AdminShell
+      title="Tạo đề Thi thử Tin học"
+      description="Mặc định 24 câu trắc nghiệm 4 lựa chọn + 4 câu Đúng/Sai (mỗi câu 4 ý). Khi lưu sẽ tự hiển thị cho user trong môn Tin học."
+    >
       <section className="space-y-4 rounded-2xl border bg-card p-4">
         <div className="grid gap-3 md:grid-cols-2">
-          <Input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Tiêu đề đề thi thử" />
-          <Input value={duration} onChange={(e) => setDuration(e.target.value)} inputMode="numeric" placeholder="Thời gian (phút)" />
+          <Input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Tiêu đề đề thi thử"
+          />
+          <Input
+            value={duration}
+            onChange={(e) => setDuration(e.target.value)}
+            inputMode="numeric"
+            placeholder="Thời gian (phút)"
+          />
         </div>
         <p className="text-xs text-muted-foreground">Đã điền: {totalFilled}/28 cụm câu.</p>
 
         <h3 className="font-bold">Phần I - 24 câu trắc nghiệm</h3>
         <div className="space-y-3">
           {mcq.map((q, i) => (
-            <div key={i} className="rounded-xl border p-3 space-y-2">
-              <Input value={q.questionCode} onChange={(e) => setMcq((cur) => cur.map((x, idx) => idx === i ? { ...x, questionCode: e.target.value } : x))} placeholder={`Mã câu gợi ý TH-MC-${String(i+1).padStart(3,"0")}`} />
-              <Textarea value={q.prompt} onChange={(e) => setMcq((cur) => cur.map((x, idx) => idx === i ? { ...x, prompt: e.target.value } : x))} placeholder={`Câu ${i + 1}`} />
+            <div key={i} className="space-y-2 rounded-xl border p-3">
+              <Input
+                value={q.questionCode}
+                onChange={(e) =>
+                  setMcq((cur) =>
+                    cur.map((x, idx) => (idx === i ? { ...x, questionCode: e.target.value } : x)),
+                  )
+                }
+                placeholder={`Mã câu gợi ý TH-MC-${String(i + 1).padStart(3, "0")}`}
+              />
+              <Textarea
+                value={q.prompt}
+                onChange={(e) =>
+                  setMcq((cur) => cur.map((x, idx) => (idx === i ? { ...x, prompt: e.target.value } : x)))
+                }
+                placeholder={`Câu ${i + 1}`}
+              />
               <div className="grid grid-cols-2 gap-2">
                 {q.options.map((op, oi) => (
-                  <Input key={oi} value={op} onChange={(e) => setMcq((cur) => cur.map((x, idx) => idx === i ? { ...x, options: x.options.map((v, vi) => vi === oi ? e.target.value : v) } : x))} placeholder={`Đáp án ${String.fromCharCode(65 + oi)}`} />
+                  <Input
+                    key={oi}
+                    value={op}
+                    onChange={(e) =>
+                      setMcq((cur) =>
+                        cur.map((x, idx) =>
+                          idx === i
+                            ? {
+                                ...x,
+                                options: x.options.map((v, vi) =>
+                                  vi === oi ? e.target.value : v,
+                                ),
+                              }
+                            : x,
+                        ),
+                      )
+                    }
+                    placeholder={`Đáp án ${String.fromCharCode(65 + oi)}`}
+                  />
                 ))}
               </div>
-              <div className="flex gap-2">{[0,1,2,3].map((n) => <Button key={n} type="button" variant={q.correctIndex===n?"default":"outline"} onClick={() => setMcq((cur)=>cur.map((x,idx)=>idx===i?{...x,correctIndex:n}:x))}>{String.fromCharCode(65+n)}</Button>)}</div>
+              <div className="flex gap-2">
+                {[0, 1, 2, 3].map((n) => (
+                  <Button
+                    key={n}
+                    type="button"
+                    variant={q.correctIndex === n ? "default" : "outline"}
+                    onClick={() =>
+                      setMcq((cur) =>
+                        cur.map((x, idx) => (idx === i ? { ...x, correctIndex: n } : x)),
+                      )
+                    }
+                  >
+                    {String.fromCharCode(65 + n)}
+                  </Button>
+                ))}
+              </div>
             </div>
           ))}
         </div>
@@ -116,15 +210,97 @@ export default function AdminMockExamInformaticsPage() {
         <h3 className="font-bold">Phần II - 4 câu Đúng/Sai (mỗi câu 4 ý)</h3>
         <div className="space-y-3">
           {tfGroups.map((g, gi) => (
-            <div key={gi} className="rounded-xl border p-3 space-y-2">
-              <Textarea value={g.prompt} onChange={(e)=>setTfGroups((cur)=>cur.map((x,idx)=>idx===gi?{...x,prompt:e.target.value}:x))} placeholder={`Câu Đ/S ${gi+1} - đoạn dẫn`} />
+            <div key={gi} className="space-y-2 rounded-xl border p-3">
+              <Textarea
+                value={g.prompt}
+                onChange={(e) =>
+                  setTfGroups((cur) =>
+                    cur.map((x, idx) => (idx === gi ? { ...x, prompt: e.target.value } : x)),
+                  )
+                }
+                placeholder={`Câu Đ/S ${gi + 1} - đoạn dẫn`}
+              />
               {g.statements.map((s, si) => (
-                <div key={si} className="grid gap-2 md:grid-cols-[190px_1fr_auto] items-center">
-                  <Input value={s.code} onChange={(e)=>setTfGroups((cur)=>cur.map((x,idx)=>idx===gi?{...x,statements:x.statements.map((st,sti)=>sti===si?{...st,code:e.target.value}:st)}:x))} placeholder={`Mã ý gợi ý TH-DS-${gi+1}${String.fromCharCode(65+si)}`} />
-                  <Input value={s.text} onChange={(e)=>setTfGroups((cur)=>cur.map((x,idx)=>idx===gi?{...x,statements:x.statements.map((st,sti)=>sti===si?{...st,text:e.target.value}:st)}:x))} placeholder={`Ý ${String.fromCharCode(97+si)}`} />
+                <div key={si} className="grid items-center gap-2 md:grid-cols-[190px_1fr_auto]">
+                  <Input
+                    value={s.code}
+                    onChange={(e) =>
+                      setTfGroups((cur) =>
+                        cur.map((x, idx) =>
+                          idx === gi
+                            ? {
+                                ...x,
+                                statements: x.statements.map((st, sti) =>
+                                  sti === si ? { ...st, code: e.target.value } : st,
+                                ),
+                              }
+                            : x,
+                        ),
+                      )
+                    }
+                    placeholder={`Mã ý gợi ý TH-DS-${gi + 1}${String.fromCharCode(65 + si)}`}
+                  />
+                  <Input
+                    value={s.text}
+                    onChange={(e) =>
+                      setTfGroups((cur) =>
+                        cur.map((x, idx) =>
+                          idx === gi
+                            ? {
+                                ...x,
+                                statements: x.statements.map((st, sti) =>
+                                  sti === si ? { ...st, text: e.target.value } : st,
+                                ),
+                              }
+                            : x,
+                        ),
+                      )
+                    }
+                    placeholder={`Ý ${String.fromCharCode(97 + si)}`}
+                  />
                   <div className="flex gap-1">
-                    <Button type="button" size="sm" variant={s.isTrue?"default":"outline"} onClick={()=>setTfGroups((cur)=>cur.map((x,idx)=>idx===gi?{...x,statements:x.statements.map((st,sti)=>sti===si?{...st,isTrue:true}:st)}:x))}>Đúng</Button>
-                    <Button type="button" size="sm" variant={!s.isTrue?"default":"outline"} onClick={()=>setTfGroups((cur)=>cur.map((x,idx)=>idx===gi?{...x,statements:x.statements.map((st,sti)=>sti===si?{...st,isTrue:false}:st)}:x))}>Sai</Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant={s.isTrue ? "default" : "outline"}
+                      onClick={() =>
+                        setTfGroups((cur) =>
+                          cur.map((x, idx) =>
+                            idx === gi
+                              ? {
+                                  ...x,
+                                  statements: x.statements.map((st, sti) =>
+                                    sti === si ? { ...st, isTrue: true } : st,
+                                  ),
+                                }
+                              : x,
+                          ),
+                        )
+                      }
+                    >
+                      Đúng
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant={!s.isTrue ? "default" : "outline"}
+                      onClick={() =>
+                        setTfGroups((cur) =>
+                          cur.map((x, idx) =>
+                            idx === gi
+                              ? {
+                                  ...x,
+                                  statements: x.statements.map((st, sti) =>
+                                    sti === si ? { ...st, isTrue: false } : st,
+                                  ),
+                                }
+                              : x,
+                          ),
+                        )
+                      }
+                    >
+                      Sai
+                    </Button>
                   </div>
                 </div>
               ))}
@@ -132,7 +308,11 @@ export default function AdminMockExamInformaticsPage() {
           ))}
         </div>
 
-        <div className="flex justify-end"><Button type="button" onClick={() => void handleSubmit()} disabled={submitting}>{submitting ? "Đang lưu..." : "Đăng đề Thi thử Tin học"}</Button></div>
+        <div className="flex justify-end">
+          <Button type="button" onClick={() => void handleSubmit()} disabled={submitting}>
+            {submitting ? "Đang lưu..." : "Đăng đề Thi thử Tin học"}
+          </Button>
+        </div>
       </section>
     </AdminShell>
   );

--- a/frontend/src/pages/AdminMockExamInformaticsPage.tsx
+++ b/frontend/src/pages/AdminMockExamInformaticsPage.tsx
@@ -2,7 +2,10 @@ import AdminShell from "@/components/admin/AdminShell";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { adminService, type AdminCreateExamPayload } from "@/services/adminService";
+import {
+  adminService,
+  type AdminCreateExamPayload,
+} from "@/services/adminService";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 
@@ -25,7 +28,11 @@ type TfGroup = {
 };
 
 const sanitizeCode = (value: string) =>
-  value.trim().toUpperCase().replace(/\s+/g, "").replace(/[^A-Z0-9._-]/g, "");
+  value
+    .trim()
+    .toUpperCase()
+    .replace(/\s+/g, "")
+    .replace(/[^A-Z0-9._-]/g, "");
 
 const createMcq = (): McqQuestion => ({
   questionCode: "",
@@ -46,8 +53,12 @@ const createTfGroup = (): TfGroup => ({
 export default function AdminMockExamInformaticsPage() {
   const [title, setTitle] = useState("");
   const [duration, setDuration] = useState("50");
-  const [mcq, setMcq] = useState<McqQuestion[]>(Array.from({ length: 24 }, createMcq));
-  const [tfGroups, setTfGroups] = useState<TfGroup[]>(Array.from({ length: 4 }, createTfGroup));
+  const [mcq, setMcq] = useState<McqQuestion[]>(
+    Array.from({ length: 24 }, createMcq),
+  );
+  const [tfGroups] = useState<TfGroup[]>(
+    Array.from({ length: 4 }, createTfGroup),
+  );
   const [submitting, setSubmitting] = useState(false);
 
   const totalFilled = useMemo(() => {
@@ -69,7 +80,7 @@ export default function AdminMockExamInformaticsPage() {
     const missingMcqIndex = mcq.findIndex(
       (q) =>
         !q.prompt.trim() ||
-        q.options.map((o) => o.trim()).filter(Boolean).length < 4
+        q.options.map((o) => o.trim()).filter(Boolean).length < 4,
     );
     if (missingMcqIndex >= 0) {
       return toast.error(`Câu ${missingMcqIndex + 1} chưa đủ 4 đáp án.`);
@@ -77,9 +88,7 @@ export default function AdminMockExamInformaticsPage() {
 
     // Validate TF
     const missingTfIndex = tfGroups.findIndex(
-      (g) =>
-        !g.prompt.trim() ||
-        g.statements.some((s) => !s.text.trim())
+      (g) => !g.prompt.trim() || g.statements.some((s) => !s.text.trim()),
     );
     if (missingTfIndex >= 0) {
       return toast.error(`Câu Đ/S ${missingTfIndex + 1} chưa đủ dữ liệu.`);
@@ -99,7 +108,7 @@ export default function AdminMockExamInformaticsPage() {
         explanationTitle: `Câu Đ/S ${gi + 1}${String.fromCharCode(97 + si)}`,
         explanationSteps: [],
         explanationConclusion: "",
-      }))
+      })),
     );
 
     const payload: AdminCreateExamPayload = {
@@ -149,8 +158,16 @@ export default function AdminMockExamInformaticsPage() {
     >
       <section className="space-y-4 rounded-2xl border bg-card p-4">
         <div className="grid gap-3 md:grid-cols-2">
-          <Input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Tiêu đề" />
-          <Input value={duration} onChange={(e) => setDuration(e.target.value)} placeholder="Thời gian (phút)" />
+          <Input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Tiêu đề"
+          />
+          <Input
+            value={duration}
+            onChange={(e) => setDuration(e.target.value)}
+            placeholder="Thời gian (phút)"
+          />
         </div>
 
         <p>Đã điền: {totalFilled}/28</p>
@@ -163,8 +180,8 @@ export default function AdminMockExamInformaticsPage() {
               onChange={(e) =>
                 setMcq((cur) =>
                   cur.map((x, idx) =>
-                    idx === i ? { ...x, questionCode: e.target.value } : x
-                  )
+                    idx === i ? { ...x, questionCode: e.target.value } : x,
+                  ),
                 )
               }
               placeholder={`TH-MC-${i + 1}`}
@@ -174,8 +191,8 @@ export default function AdminMockExamInformaticsPage() {
               onChange={(e) =>
                 setMcq((cur) =>
                   cur.map((x, idx) =>
-                    idx === i ? { ...x, prompt: e.target.value } : x
-                  )
+                    idx === i ? { ...x, prompt: e.target.value } : x,
+                  ),
                 )
               }
               placeholder={`Câu ${i + 1}`}

--- a/frontend/src/pages/AdminMockExamInformaticsPage.tsx
+++ b/frontend/src/pages/AdminMockExamInformaticsPage.tsx
@@ -64,15 +64,33 @@ export default function AdminMockExamInformaticsPage() {
       return toast.error("Thời lượng không hợp lệ.");
     }
 
+    const missingMcqIndex = mcq.findIndex(
+      (question) =>
+        !question.prompt.trim() ||
+        question.options.map((option) => option.trim()).filter(Boolean).length < 4,
+    );
+
+    if (missingMcqIndex >= 0) {
+      return toast.error(`Câu trắc nghiệm ${missingMcqIndex + 1} chưa đủ nội dung hoặc 4 đáp án.`);
+    }
+
+    const missingTfGroupIndex = tfGroups.findIndex(
+      (group) =>
+        !group.prompt.trim() ||
+        group.statements.some((statement) => !statement.text.trim()),
+    );
+
+    if (missingTfGroupIndex >= 0) {
+      return toast.error(`Câu đúng/sai ${missingTfGroupIndex + 1} chưa đủ đoạn dẫn hoặc các ý.`);
+    }
+
     const flattenedTrueFalse = tfGroups.flatMap((group, groupIndex) =>
       group.statements.map((item, statementIndex) => ({
         topicLabel: "Đúng/Sai",
         questionCode:
           sanitizeCode(item.code) ||
           `TH-DS-${groupIndex + 1}${String.fromCharCode(65 + statementIndex)}`,
-        prompt: `${group.prompt.trim()}\nÝ ${String.fromCharCode(97 + statementIndex)}: ${
-          item.text
-        }`,
+        prompt: `${group.prompt.trim()}\nÝ ${String.fromCharCode(97 + statementIndex)}: ${item.text.trim()}`,
         options: ["Đúng", "Sai"],
         correctIndex: item.isTrue ? 0 : 1,
         hint: "",

--- a/frontend/src/pages/AdminMockExamInformaticsPage.tsx
+++ b/frontend/src/pages/AdminMockExamInformaticsPage.tsx
@@ -1,0 +1,139 @@
+import AdminShell from "@/components/admin/AdminShell";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { adminService, type AdminCreateExamPayload } from "@/services/adminService";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+
+type McqQuestion = { questionCode: string; prompt: string; options: string[]; correctIndex: number };
+type TfGroup = { prompt: string; statements: Array<{ code: string; text: string; isTrue: boolean }> };
+
+const createMcq = (): McqQuestion => ({ questionCode: "", prompt: "", options: ["", "", "", ""], correctIndex: 0 });
+const createTfGroup = (): TfGroup => ({
+  prompt: "",
+  statements: Array.from({ length: 4 }, () => ({ code: "", text: "", isTrue: true })),
+});
+
+export default function AdminMockExamInformaticsPage() {
+  const [title, setTitle] = useState("");
+  const [duration, setDuration] = useState("50");
+  const [mcq, setMcq] = useState<McqQuestion[]>(Array.from({ length: 24 }, createMcq));
+  const [tfGroups, setTfGroups] = useState<TfGroup[]>(Array.from({ length: 4 }, createTfGroup));
+  const [submitting, setSubmitting] = useState(false);
+
+  const totalFilled = useMemo(() => {
+    const mcqFilled = mcq.filter((q) => q.prompt.trim()).length;
+    const tfFilled = tfGroups.filter((g) => g.prompt.trim()).length;
+    return mcqFilled + tfFilled;
+  }, [mcq, tfGroups]);
+
+  const handleSubmit = async () => {
+    const examTitle = title.trim();
+    const durationMinutes = Number(duration);
+
+    if (!examTitle) return toast.error("Nhập tiêu đề đề thi.");
+    if (!Number.isFinite(durationMinutes) || durationMinutes < 1) return toast.error("Thời lượng không hợp lệ.");
+
+    const flattenedTrueFalse = tfGroups.flatMap((group, groupIndex) =>
+      group.statements.map((item, statementIndex) => ({
+        topicLabel: "Đúng/Sai",
+        questionCode: (item.code || `TH-DS-${groupIndex + 1}${String.fromCharCode(65 + statementIndex)}`).trim().toUpperCase().replace(/\s+/g, ""),
+        prompt: `${group.prompt.trim()}\nÝ ${String.fromCharCode(97 + statementIndex)}: ${item.text.trim()}`,
+        options: ["Đúng", "Sai"],
+        correctIndex: item.isTrue ? 0 : 1,
+        hint: "",
+        formula: "",
+        explanationTitle: `Câu Đ/S ${groupIndex + 1}${String.fromCharCode(97 + statementIndex)}`,
+        explanationSteps: [],
+        explanationConclusion: "",
+      }))
+    );
+
+    const payload: AdminCreateExamPayload = {
+      subject: "Tin học",
+      examType: "multiple_choice",
+      title: examTitle,
+      durationMinutes,
+      difficulty: "Khó",
+      category: "specialized",
+      badge: "Thi thử mới",
+      imageUrl: "",
+      questions: [
+        ...mcq.map((question, index) => ({
+          topicLabel: "Trắc nghiệm 4 lựa chọn",
+          questionCode: (question.questionCode || `TH-MC-${String(index + 1).padStart(3, "0")}`).trim().toUpperCase().replace(/\s+/g, ""),
+          prompt: question.prompt.trim() || `Câu ${index + 1}`,
+          options: question.options.map((o) => o.trim()).filter(Boolean),
+          correctIndex: question.correctIndex,
+          hint: "",
+          formula: "",
+          explanationTitle: "",
+          explanationSteps: [],
+          explanationConclusion: "",
+        })),
+        ...flattenedTrueFalse,
+      ],
+    };
+
+    try {
+      setSubmitting(true);
+      await adminService.createExam(payload);
+      toast.success("Đã đẩy đề lên Thi thử môn Tin học.");
+    } catch (error) {
+      console.error(error);
+      toast.error("Tạo đề thất bại.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <AdminShell title="Tạo đề Thi thử Tin học" description="Mặc định 24 câu trắc nghiệm 4 lựa chọn + 4 câu Đúng/Sai (mỗi câu 4 ý). Khi lưu sẽ tự hiển thị cho user trong môn Tin học.">
+      <section className="space-y-4 rounded-2xl border bg-card p-4">
+        <div className="grid gap-3 md:grid-cols-2">
+          <Input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Tiêu đề đề thi thử" />
+          <Input value={duration} onChange={(e) => setDuration(e.target.value)} inputMode="numeric" placeholder="Thời gian (phút)" />
+        </div>
+        <p className="text-xs text-muted-foreground">Đã điền: {totalFilled}/28 cụm câu.</p>
+
+        <h3 className="font-bold">Phần I - 24 câu trắc nghiệm</h3>
+        <div className="space-y-3">
+          {mcq.map((q, i) => (
+            <div key={i} className="rounded-xl border p-3 space-y-2">
+              <Input value={q.questionCode} onChange={(e) => setMcq((cur) => cur.map((x, idx) => idx === i ? { ...x, questionCode: e.target.value } : x))} placeholder={`Mã câu gợi ý TH-MC-${String(i+1).padStart(3,"0")}`} />
+              <Textarea value={q.prompt} onChange={(e) => setMcq((cur) => cur.map((x, idx) => idx === i ? { ...x, prompt: e.target.value } : x))} placeholder={`Câu ${i + 1}`} />
+              <div className="grid grid-cols-2 gap-2">
+                {q.options.map((op, oi) => (
+                  <Input key={oi} value={op} onChange={(e) => setMcq((cur) => cur.map((x, idx) => idx === i ? { ...x, options: x.options.map((v, vi) => vi === oi ? e.target.value : v) } : x))} placeholder={`Đáp án ${String.fromCharCode(65 + oi)}`} />
+                ))}
+              </div>
+              <div className="flex gap-2">{[0,1,2,3].map((n) => <Button key={n} type="button" variant={q.correctIndex===n?"default":"outline"} onClick={() => setMcq((cur)=>cur.map((x,idx)=>idx===i?{...x,correctIndex:n}:x))}>{String.fromCharCode(65+n)}</Button>)}</div>
+            </div>
+          ))}
+        </div>
+
+        <h3 className="font-bold">Phần II - 4 câu Đúng/Sai (mỗi câu 4 ý)</h3>
+        <div className="space-y-3">
+          {tfGroups.map((g, gi) => (
+            <div key={gi} className="rounded-xl border p-3 space-y-2">
+              <Textarea value={g.prompt} onChange={(e)=>setTfGroups((cur)=>cur.map((x,idx)=>idx===gi?{...x,prompt:e.target.value}:x))} placeholder={`Câu Đ/S ${gi+1} - đoạn dẫn`} />
+              {g.statements.map((s, si) => (
+                <div key={si} className="grid grid-cols-[1fr_auto] gap-2 items-center">
+                  <Input value={s.code} onChange={(e)=>setTfGroups((cur)=>cur.map((x,idx)=>idx===gi?{...x,statements:x.statements.map((st,sti)=>sti===si?{...st,code:e.target.value}:st)}:x))} placeholder={`Mã ý gợi ý TH-DS-${gi+1}${String.fromCharCode(65+si)}`} />
+                  <Input value={s.text} onChange={(e)=>setTfGroups((cur)=>cur.map((x,idx)=>idx===gi?{...x,statements:x.statements.map((st,sti)=>sti===si?{...st,text:e.target.value}:st)}:x))} placeholder={`Ý ${String.fromCharCode(97+si)}`} />
+                  <div className="flex gap-1">
+                    <Button type="button" size="sm" variant={s.isTrue?"default":"outline"} onClick={()=>setTfGroups((cur)=>cur.map((x,idx)=>idx===gi?{...x,statements:x.statements.map((st,sti)=>sti===si?{...st,isTrue:true}:st)}:x))}>Đúng</Button>
+                    <Button type="button" size="sm" variant={!s.isTrue?"default":"outline"} onClick={()=>setTfGroups((cur)=>cur.map((x,idx)=>idx===gi?{...x,statements:x.statements.map((st,sti)=>sti===si?{...st,isTrue:false}:st)}:x))}>Sai</Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+
+        <div className="flex justify-end"><Button type="button" onClick={() => void handleSubmit()} disabled={submitting}>{submitting ? "Đang lưu..." : "Đăng đề Thi thử Tin học"}</Button></div>
+      </section>
+    </AdminShell>
+  );
+}

--- a/frontend/src/pages/AdminMockExamInformaticsPage.tsx
+++ b/frontend/src/pages/AdminMockExamInformaticsPage.tsx
@@ -9,6 +9,7 @@ import {
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 
+// ===== TYPES =====
 type McqQuestion = {
   questionCode: string;
   prompt: string;
@@ -27,6 +28,7 @@ type TfGroup = {
   statements: TfStatement[];
 };
 
+// ===== HELPERS =====
 const sanitizeCode = (value: string) =>
   value
     .trim()
@@ -50,13 +52,14 @@ const createTfGroup = (): TfGroup => ({
   })),
 });
 
+// ===== COMPONENT =====
 export default function AdminMockExamInformaticsPage() {
   const [title, setTitle] = useState("");
   const [duration, setDuration] = useState("50");
   const [mcq, setMcq] = useState<McqQuestion[]>(
     Array.from({ length: 24 }, createMcq),
   );
-  const [tfGroups] = useState<TfGroup[]>(
+  const [tfGroups, setTfGroups] = useState<TfGroup[]>(
     Array.from({ length: 4 }, createTfGroup),
   );
   const [submitting, setSubmitting] = useState(false);
@@ -172,36 +175,189 @@ export default function AdminMockExamInformaticsPage() {
 
         <p>Đã điền: {totalFilled}/28</p>
 
-        {/* MCQ */}
-        {mcq.map((q, i) => (
-          <div key={i} className="border p-3 rounded">
-            <Input
-              value={q.questionCode}
-              onChange={(e) =>
-                setMcq((cur) =>
-                  cur.map((x, idx) =>
-                    idx === i ? { ...x, questionCode: e.target.value } : x,
-                  ),
-                )
-              }
-              placeholder={`TH-MC-${i + 1}`}
-            />
-            <Textarea
-              value={q.prompt}
-              onChange={(e) =>
-                setMcq((cur) =>
-                  cur.map((x, idx) =>
-                    idx === i ? { ...x, prompt: e.target.value } : x,
-                  ),
-                )
-              }
-              placeholder={`Câu ${i + 1}`}
-            />
-          </div>
-        ))}
+        <h3 className="font-bold">Phần I - 24 câu trắc nghiệm</h3>
+        <div className="space-y-3">
+          {mcq.map((q, i) => (
+            <div key={i} className="space-y-2 rounded-xl border p-3">
+              <Input
+                value={q.questionCode}
+                onChange={(e) =>
+                  setMcq((cur) =>
+                    cur.map((x, idx) =>
+                      idx === i ? { ...x, questionCode: e.target.value } : x,
+                    ),
+                  )
+                }
+                placeholder={`Mã câu gợi ý TH-MC-${String(i + 1).padStart(3, "0")}`}
+              />
+              <Textarea
+                value={q.prompt}
+                onChange={(e) =>
+                  setMcq((cur) =>
+                    cur.map((x, idx) =>
+                      idx === i ? { ...x, prompt: e.target.value } : x,
+                    ),
+                  )
+                }
+                placeholder={`Câu ${i + 1}`}
+              />
+              <div className="grid grid-cols-2 gap-2">
+                {q.options.map((op, oi) => (
+                  <Input
+                    key={oi}
+                    value={op}
+                    onChange={(e) =>
+                      setMcq((cur) =>
+                        cur.map((x, idx) =>
+                          idx === i
+                            ? {
+                                ...x,
+                                options: x.options.map((v, vi) =>
+                                  vi === oi ? e.target.value : v,
+                                ),
+                              }
+                            : x,
+                        ),
+                      )
+                    }
+                    placeholder={`Đáp án ${String.fromCharCode(65 + oi)}`}
+                  />
+                ))}
+              </div>
+              <div className="flex gap-2">
+                {[0, 1, 2, 3].map((n) => (
+                  <Button
+                    key={n}
+                    type="button"
+                    variant={q.correctIndex === n ? "default" : "outline"}
+                    onClick={() =>
+                      setMcq((cur) =>
+                        cur.map((x, idx) =>
+                          idx === i ? { ...x, correctIndex: n } : x,
+                        ),
+                      )
+                    }
+                  >
+                    {String.fromCharCode(65 + n)}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <h3 className="font-bold">Phần II - 4 câu Đúng/Sai (mỗi câu 4 ý)</h3>
+        <div className="space-y-3">
+          {tfGroups.map((g, gi) => (
+            <div key={gi} className="space-y-2 rounded-xl border p-3">
+              <Textarea
+                value={g.prompt}
+                onChange={(e) =>
+                  setTfGroups((cur) =>
+                    cur.map((x, idx) =>
+                      idx === gi ? { ...x, prompt: e.target.value } : x,
+                    ),
+                  )
+                }
+                placeholder={`Câu Đ/S ${gi + 1} - đoạn dẫn`}
+              />
+              {g.statements.map((s, si) => (
+                <div
+                  key={si}
+                  className="grid items-center gap-2 md:grid-cols-[190px_1fr_auto]"
+                >
+                  <Input
+                    value={s.code}
+                    onChange={(e) =>
+                      setTfGroups((cur) =>
+                        cur.map((x, idx) =>
+                          idx === gi
+                            ? {
+                                ...x,
+                                statements: x.statements.map((st, sti) =>
+                                  sti === si
+                                    ? { ...st, code: e.target.value }
+                                    : st,
+                                ),
+                              }
+                            : x,
+                        ),
+                      )
+                    }
+                    placeholder={`Mã ý gợi ý TH-DS-${gi + 1}${String.fromCharCode(65 + si)}`}
+                  />
+                  <Input
+                    value={s.text}
+                    onChange={(e) =>
+                      setTfGroups((cur) =>
+                        cur.map((x, idx) =>
+                          idx === gi
+                            ? {
+                                ...x,
+                                statements: x.statements.map((st, sti) =>
+                                  sti === si
+                                    ? { ...st, text: e.target.value }
+                                    : st,
+                                ),
+                              }
+                            : x,
+                        ),
+                      )
+                    }
+                    placeholder={`Ý ${String.fromCharCode(97 + si)}`}
+                  />
+                  <div className="flex gap-1">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant={s.isTrue ? "default" : "outline"}
+                      onClick={() =>
+                        setTfGroups((cur) =>
+                          cur.map((x, idx) =>
+                            idx === gi
+                              ? {
+                                  ...x,
+                                  statements: x.statements.map((st, sti) =>
+                                    sti === si ? { ...st, isTrue: true } : st,
+                                  ),
+                                }
+                              : x,
+                          ),
+                        )
+                      }
+                    >
+                      Đúng
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant={!s.isTrue ? "default" : "outline"}
+                      onClick={() =>
+                        setTfGroups((cur) =>
+                          cur.map((x, idx) =>
+                            idx === gi
+                              ? {
+                                  ...x,
+                                  statements: x.statements.map((st, sti) =>
+                                    sti === si ? { ...st, isTrue: false } : st,
+                                  ),
+                                }
+                              : x,
+                          ),
+                        )
+                      }
+                    >
+                      Sai
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
 
         <div className="flex justify-end">
-          <Button onClick={handleSubmit} disabled={submitting}>
+          <Button type="button" onClick={handleSubmit} disabled={submitting}>
             {submitting ? "Đang lưu..." : "Đăng đề"}
           </Button>
         </div>

--- a/frontend/src/pages/AdminMockExamInformaticsPage.tsx
+++ b/frontend/src/pages/AdminMockExamInformaticsPage.tsx
@@ -119,7 +119,7 @@ export default function AdminMockExamInformaticsPage() {
             <div key={gi} className="rounded-xl border p-3 space-y-2">
               <Textarea value={g.prompt} onChange={(e)=>setTfGroups((cur)=>cur.map((x,idx)=>idx===gi?{...x,prompt:e.target.value}:x))} placeholder={`Câu Đ/S ${gi+1} - đoạn dẫn`} />
               {g.statements.map((s, si) => (
-                <div key={si} className="grid grid-cols-[1fr_auto] gap-2 items-center">
+                <div key={si} className="grid gap-2 md:grid-cols-[190px_1fr_auto] items-center">
                   <Input value={s.code} onChange={(e)=>setTfGroups((cur)=>cur.map((x,idx)=>idx===gi?{...x,statements:x.statements.map((st,sti)=>sti===si?{...st,code:e.target.value}:st)}:x))} placeholder={`Mã ý gợi ý TH-DS-${gi+1}${String.fromCharCode(65+si)}`} />
                   <Input value={s.text} onChange={(e)=>setTfGroups((cur)=>cur.map((x,idx)=>idx===gi?{...x,statements:x.statements.map((st,sti)=>sti===si?{...st,text:e.target.value}:st)}:x))} placeholder={`Ý ${String.fromCharCode(97+si)}`} />
                   <div className="flex gap-1">

--- a/frontend/src/pages/ExamResultPage.tsx
+++ b/frontend/src/pages/ExamResultPage.tsx
@@ -88,6 +88,10 @@ const ExamResultPage = () => {
       return 0;
     }
 
+    if (typeof result.score === "number") {
+      return result.score;
+    }
+
     return calculateExamScore(
       result.correctCount,
       result.totalQuestions,

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -104,8 +104,8 @@ const HomePage = () => {
         progressPercentage: 0,
       }
   );
-  const studyGoals = user?.studyGoals?.subjects ?? [];
   const selectedSubjects = useMemo(() => {
+    const studyGoals = user?.studyGoals?.subjects ?? [];
     if (studyGoals.length > 0) {
       return studyGoals;
     }
@@ -115,7 +115,7 @@ const HomePage = () => {
       currentScore: 0,
       targetScore: 10,
     }));
-  }, [studyGoals, user?.studyGoals?.selectedSubjects]);
+  }, [user?.studyGoals?.selectedSubjects, user?.studyGoals?.subjects]);
   const hasStudyGoals =
     selectedSubjects.length > 0 || (user?.studyGoals?.selectedSubjects?.length ?? 0) > 0;
   const subjectSetupInitialValue = useMemo(
@@ -167,7 +167,7 @@ const HomePage = () => {
     return () => {
       cancelled = true;
     };
-  }, [setRemoteNotifications, user]);
+  }, [conversations, setRemoteNotifications, user]);
 
   useEffect(() => {
     let cancelled = false;

--- a/frontend/src/pages/LiteratureExamPage.tsx
+++ b/frontend/src/pages/LiteratureExamPage.tsx
@@ -85,7 +85,7 @@ const LiteratureExamPage = () => {
     }, 1000);
 
     return () => window.clearInterval(timer);
-  }, [exam]);
+  }, [exam, timeLeft]);
 
   if (!exam || timeLeft === null || !exam.essayContent) {
     return null;

--- a/frontend/src/pages/MultipleChoiceExamPage.tsx
+++ b/frontend/src/pages/MultipleChoiceExamPage.tsx
@@ -29,7 +29,7 @@ import {
   Square,
   Tag,
 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 
@@ -141,7 +141,6 @@ const MultipleChoiceExamPage = () => {
   const exitEventsRef = useRef<string[]>([]);
   const autoSubmittedRef = useRef(false);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (!examId) {
       navigate("/practice", { replace: true });
@@ -260,7 +259,6 @@ const MultipleChoiceExamPage = () => {
     return exam.questions.filter((question) => selectedSet.has(question.topicLabel?.trim() || ""));
   }, [exam, selectedTopicLabels, topicOptions]);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (!hasStarted || !preparedQuestions.length || timeLeft === null) {
       return undefined;
@@ -279,7 +277,7 @@ const MultipleChoiceExamPage = () => {
     return () => window.clearInterval(timer);
   }, [hasStarted, preparedQuestions.length, timeLeft]);
 
-  const handleSubmitExam = async (
+  const handleSubmitExam = useCallback(async (
     autoSubmit = false,
     antiCheatOverride?: {
       suspiciousExitCount: number;
@@ -389,9 +387,21 @@ const MultipleChoiceExamPage = () => {
       setIsSubmitting(false);
       setConfirmOpen(false);
     }
-  };
+  }, [
+    attemptExamId,
+    durationMinutes,
+    exam,
+    isSubmitting,
+    launchState?.launchSource,
+    navigate,
+    preparedQuestions,
+    selectedAnswers,
+    selectedTopicLabels,
+    timeLeft,
+    user?.displayName,
+    user?.username,
+  ]);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (!hasStarted || timeLeft !== 0) {
       return;
@@ -471,7 +481,7 @@ const MultipleChoiceExamPage = () => {
     );
   };
 
-  const handleStartExam = () => {
+  const handleStartExam = useCallback(() => {
     if (!exam) {
       return;
     }
@@ -523,7 +533,7 @@ const MultipleChoiceExamPage = () => {
           })
         : exam.examId
     );
-  };
+  }, [availableQuestions, durationMinutes, exam, questionLimit, selectedTopicLabels]);
 
   useEffect(() => {
     if (!exam || !launchState?.autoStart || hasStarted || selectedTopicLabels.length === 0) {

--- a/frontend/src/pages/MultipleChoiceExamPage.tsx
+++ b/frontend/src/pages/MultipleChoiceExamPage.tsx
@@ -141,6 +141,7 @@ const MultipleChoiceExamPage = () => {
   const exitEventsRef = useRef<string[]>([]);
   const autoSubmittedRef = useRef(false);
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (!examId) {
       navigate("/practice", { replace: true });
@@ -230,7 +231,7 @@ const MultipleChoiceExamPage = () => {
     return () => {
       cancelled = true;
     };
-  }, [examId, launchState?.durationMinutes, launchState?.questionLimit, launchState?.selectedTopicLabels, navigate, subjectSlug]);
+  }, [examId, launchState?.durationMinutes, launchState?.initialExamDetail, launchState?.questionLimit, launchState?.selectedTopicLabels, navigate, subjectSlug]);
 
   const topicOptions = useMemo(() => {
     if (!exam) {
@@ -259,6 +260,7 @@ const MultipleChoiceExamPage = () => {
     return exam.questions.filter((question) => selectedSet.has(question.topicLabel?.trim() || ""));
   }, [exam, selectedTopicLabels, topicOptions]);
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (!hasStarted || !preparedQuestions.length || timeLeft === null) {
       return undefined;
@@ -389,13 +391,14 @@ const MultipleChoiceExamPage = () => {
     }
   };
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (!hasStarted || timeLeft !== 0) {
       return;
     }
 
     void handleSubmitExam(true);
-  }, [hasStarted, timeLeft]);
+  }, [handleSubmitExam, hasStarted, timeLeft]);
 
   useEffect(() => {
     if (!hasStarted) {
@@ -452,7 +455,7 @@ const MultipleChoiceExamPage = () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       window.removeEventListener("beforeunload", handleBeforeUnload);
     };
-  }, [hasStarted, isSubmitting]);
+  }, [handleSubmitExam, hasStarted, isSubmitting]);
 
   const handleToggleTopic = (topicLabel: string) => {
     setSelectedTopicLabels((current) =>
@@ -528,7 +531,7 @@ const MultipleChoiceExamPage = () => {
     }
 
     handleStartExam();
-  }, [exam, hasStarted, launchState?.autoStart, selectedTopicLabels]);
+  }, [exam, handleStartExam, hasStarted, launchState?.autoStart, selectedTopicLabels]);
 
   if (isLoadingExam) {
     return (

--- a/frontend/src/pages/MultipleChoiceExamPage.tsx
+++ b/frontend/src/pages/MultipleChoiceExamPage.tsx
@@ -83,6 +83,37 @@ const buildInformaticsAttemptExamId = ({
   ].join("__");
 };
 
+const calculateInformaticsMockScore = (
+  questions: ExamQuestion[],
+  answers: Record<number, number>,
+) => {
+  const scoreByTfCorrectCount = [0, 0.1, 0.25, 0.5, 1];
+  let totalScore = 0;
+  let trueFalseBucket: boolean[] = [];
+
+  questions.forEach((question, index) => {
+    const picked = answers[question.id];
+    const isCorrect = picked === question.correctIndex;
+    const isTrueFalse = question.topicLabel?.trim() === "Đúng/Sai";
+
+    if (!isTrueFalse && index < 24) {
+      totalScore += isCorrect ? 0.25 : 0;
+      return;
+    }
+
+    if (isTrueFalse) {
+      trueFalseBucket.push(isCorrect);
+      if (trueFalseBucket.length === 4) {
+        const correctInGroup = trueFalseBucket.filter(Boolean).length;
+        totalScore += scoreByTfCorrectCount[correctInGroup] ?? 0;
+        trueFalseBucket = [];
+      }
+    }
+  });
+
+  return Math.round(totalScore * 100) / 100;
+};
+
 const MultipleChoiceExamPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -268,6 +299,10 @@ const MultipleChoiceExamPage = () => {
         return count + Number(question?.correctIndex === answerIndex);
       }, 0);
       const wrongCount = selectedEntries.length - correctCount;
+      const customScore =
+        exam.subjectSlug === "tin-hoc" && preparedQuestions.length >= 40
+          ? calculateInformaticsMockScore(preparedQuestions, selectedAnswers)
+          : undefined;
       const timeSpentSeconds = durationMinutes * 60 - timeLeft;
       const rankingExamId =
         exam.subjectSlug === "tin-hoc"
@@ -309,6 +344,7 @@ const MultipleChoiceExamPage = () => {
         topicAnalysis: calculateTopicAnalysis(preparedQuestions, selectedAnswers),
         selectedAnswers,
         questions: preparedQuestions,
+        score: customScore,
       };
 
       saveLastExamResult(resultState);
@@ -328,9 +364,10 @@ const MultipleChoiceExamPage = () => {
               correctCount,
               totalQuestions: preparedQuestions.length,
               score:
-                preparedQuestions.length > 0
+                customScore ??
+                (preparedQuestions.length > 0
                   ? (correctCount / preparedQuestions.length) * 10
-                  : 0,
+                  : 0),
               timeSpentSeconds,
             })
           );

--- a/frontend/src/services/adminService.ts
+++ b/frontend/src/services/adminService.ts
@@ -79,6 +79,7 @@ export interface AdminAnalyticsResponse {
 
 export interface AdminCreateExamQuestionPayload {
   topicLabel?: string;
+  questionCode?: string;
   prompt: string;
   imageUrl?: string;
   hint?: string;

--- a/frontend/src/services/adminService.ts
+++ b/frontend/src/services/adminService.ts
@@ -20,8 +20,10 @@ export interface AdminOverviewResponse {
   latestUsers: AdminOverviewUser[];
 }
 
-export interface AdminNotificationTargetUser
-  extends Pick<User, "_id" | "username" | "displayName" | "avatarUrl" | "classroom" | "userCode"> {}
+export type AdminNotificationTargetUser = Pick<
+  User,
+  "_id" | "username" | "displayName" | "avatarUrl" | "classroom" | "userCode"
+>;
 
 export interface AdminNotificationRecord {
   id: string;

--- a/frontend/src/types/exam.ts
+++ b/frontend/src/types/exam.ts
@@ -10,6 +10,7 @@ export type TopicAnalysisItem = {
 export type ExamQuestion = {
   id: number;
   topicLabel?: string;
+  questionCode?: string;
   prompt: string;
   imageUrl?: string;
   hint: string;

--- a/frontend/src/types/examResult.ts
+++ b/frontend/src/types/examResult.ts
@@ -14,4 +14,5 @@ export type ExamResultState = {
   topicAnalysis: TopicAnalysisItem[];
   selectedAnswers: Record<number, number>;
   questions: ExamQuestion[];
+  score?: number;
 };


### PR DESCRIPTION
### Motivation
- Standardize and persist per-question codes and support hint codes for authoring and searching questions.
- Provide a quick admin workflow to push a default Informatics mock exam (24 MCQ + 4 grouped True/False) and expose UI entry for it.
- Support True/False question kind in the admin builder and apply a custom scoring rule for Informatics mock attempts when calculating results.

### Description
- Backend: added `questionCode` to the `examQuestionSchema`, introduced `sanitizeQuestionCode` and populate `questionCode` when creating admin exams, and adjusted exam list sorting to include `createdAt`/`updatedAt` before `examId`.
- Frontend types and services: added optional `questionCode` to `ExamQuestion` and `ExamResultState`, and extended `adminService` payload types to accept `questionCode`.
- Admin UI: added a new `AdminMockExamInformaticsPage` to build and publish a 24-MCQ + 4-group True/False mock exam, and added menu route and link in `AdminShell` and `App` routing.
- Admin builder enhancements: added `questionCode` input, a `kind` toggle for `multiple_choice` vs `true_false`, True/False option handling and form normalization before submit.
- Exam rendering and scoring: updated `RichQuestionContent` to better handle code blocks (including triple-backtick fences) and blank lines, and patched `MultipleChoiceExamPage` to compute a special `calculateInformaticsMockScore` for Tin Học mock exams and include it in result state so `ExamResultPage` uses it when present.

### Testing
- Ran TypeScript type check (`yarn tsc --noEmit`) and frontend build (`yarn build`), both completed successfully.
- Executed frontend unit/type tests where present (`yarn test`), and they passed without regressions.
- Performed basic end-to-end manual flows locally for creating an exam via the new mock page and submitting an Informatics mock attempt to verify custom scoring and result propagation (automated tests for UI flows not added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e0f8bff08322a52253eee07ef292)