### PR TITLE
PracticePage: surface external midterm/final practice links and update UI

### DIFF
--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -60,6 +60,23 @@ type UpcomingExam = {
 
 const upcomingExams: UpcomingExam[] = [];
 const ALWAYS_AVAILABLE_PRACTICE_SUBJECTS = ["Tin học"];
+const EXTERNAL_PRACTICE_LINKS = [
+  {
+    icon: "💻",
+    label: "Thi thử Tin học",
+    url: "https://thithuthptqgtin.vercel.app",
+  },
+  {
+    icon: "⚙️",
+    label: "Thi thử Công nghệ",
+    url: "https://thithuthptqgcongnghe.vercel.app",
+  },
+  {
+    icon: "📘",
+    label: "Thi thử Toán",
+    url: "https://thithuthptqgtoan.vercel.app",
+  },
+] as const;
 
 const canonicalizePracticeSubject = (subject: string) => {
   const normalized = normalizeSubjectKey(subject);
@@ -331,7 +348,7 @@ const PracticePage = () => {
         </section>
 
         <section className="rounded-[1.4rem] border border-border/70 bg-card p-4 shadow-[0_24px_48px_-34px_hsl(var(--primary)/0.18)]">
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-col gap-4">
             <div>
               <p className="text-xs font-bold uppercase tracking-[0.18em] text-primary/80">
                 Trang mới
@@ -339,18 +356,25 @@ const PracticePage = () => {
               <h2 className="mt-2 text-lg font-black text-foreground">
                 Luyện đề giữa kì & cuối kì
               </h2>
-              <p className="mt-2 text-sm text-muted-foreground">
-                Mở trang riêng để luyện đề giữa kì và cuối kì theo mẫu đề thi
-                thử.
-              </p>
+              <div className="mt-3 space-y-2 text-sm text-muted-foreground">
+                <p>📚 Hệ thống hiện hỗ trợ các môn:</p>
+                {EXTERNAL_PRACTICE_LINKS.map(({ icon, label, url }) => (
+                  <p key={url}>
+                    {icon} {label}
+                    <br />
+                    🔗{" "}
+                    <a
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-semibold text-primary underline underline-offset-2"
+                    >
+                      {url}
+                    </a>
+                  </p>
+                ))}
+              </div>
             </div>
-            <button
-              type="button"
-              className="rounded-2xl bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary/90"
-              onClick={() => navigate("/practice/luyen-de-giua-cuoi-ki")}
-            >
-              Xem trang
-            </button>
           </div>
         </section>
 


### PR DESCRIPTION
### Motivation
- Expose external midterm/final practice pages and make supported subjects/URLs discoverable directly on the Practice page.
- Replace the previous single navigation button with an inline list of available external practice resources.

### Description
- Add `EXTERNAL_PRACTICE_LINKS` constant with icon, label, and `url` entries for Tin học, Công nghệ, and Toán. 
- Replace the old descriptive paragraph and the `navigate("/practice/luyen-de-giua-cuoi-ki")` button with a list that displays each external link, its icon, label, and a clickable URL that opens in a new tab.
- Adjust container layout classes from a two-column responsive header to a single-column stack and update spacing for the new link list.
- Keep existing practice subject handling and canonicalization logic unchanged.

### Testing
- Ran TypeScript type-checking with `yarn tsc` and no type errors were reported.
- Ran linting with `yarn lint` and automatic checks passed.
- Built the frontend with `yarn build` and the build completed successfully.
- Ran unit tests with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a102eb1cc0c8322965b61629bfa23f2)